### PR TITLE
fix: readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ load_plugins {
     nvim-nav
 }
 ```
+
+### Configuration Options
+
+The plugin supports the following configuration option:
+
+- `match_commands`: Comma-separated list of commands to match (default: `vim,nvim`)
+
+Example with custom commands:
+
+```plain
+plugins {
+    nvim-nav location="file:/home/youruser/some_dir/zellij-nvim-nav-plugin.wasm" {
+        match_commands "vim,nvim,hx"
+    }
+}
+```
  
 ```plain
     shared_except "scroll" {

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ The payload field accepts comma-separated byte values. You can refer to [ASCII
 table](https://www.asciitable.com/) to find the byte values for the keys you
 want to use.
 
+## Configuration Options
+
+The plugin supports the following configuration option:
+
+- `match_commands`: Comma-separated list of commands to match (default: `vim,nvim`)
+
 ## Example Configuration
 
 ```plain
@@ -30,22 +36,6 @@ plugins {
 ```plain
 load_plugins {
     nvim-nav
-}
-```
-
-### Configuration Options
-
-The plugin supports the following configuration option:
-
-- `match_commands`: Comma-separated list of commands to match (default: `vim,nvim`)
-
-Example with custom commands:
-
-```plain
-plugins {
-    nvim-nav location="file:/home/youruser/some_dir/zellij-nvim-nav-plugin.wasm" {
-        match_commands "vim,nvim,hx"
-    }
 }
 ```
  
@@ -72,4 +62,15 @@ plugins {
         bind "Alt k" { MessagePlugin { name "nvim_nav_up"; payload "27,107"; }; }
         bind "Alt l" { MessagePlugin { name "nvim_nav_right"; payload "27,108"; }; }
     }
+```
+
+Example with custom commands:
+
+```plain
+plugins {
+    ...
+    nvim-nav location="file:/home/youruser/some_dir/zellij-nvim-nav-plugin.wasm" {
+        match_commands "vim,nvim,hx"
+    }
+}
 ```


### PR DESCRIPTION
This PR adds documentation for the previously undocumented match_commands configuration option,
which allows users to customize which editor commands the plugin should intercept for navigation purposes.

While not explicitly requested, this feature addresses a clear need for users who want to extend the plugin's functionality beyond the default vim/nvim support to other terminal applications like fzf and similar tools.

I tested it, works like  a charm.